### PR TITLE
chore(package): update @semantic-release/* devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,12 +59,12 @@
   "devDependencies": {
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
-    "@semantic-release/changelog": "^3.0.4",
-    "@semantic-release/commit-analyzer": "^6.3.0",
+    "@semantic-release/changelog": "^5.0.1",
+    "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/error": "^2.2.0",
-    "@semantic-release/github": "^5.4.3",
-    "@semantic-release/npm": "^5.1.15",
-    "@semantic-release/release-notes-generator": "^7.3.0",
+    "@semantic-release/github": "^7.0.5",
+    "@semantic-release/npm": "^7.0.5",
+    "@semantic-release/release-notes-generator": "^9.0.1",
     "ava": "^2.3.0",
     "codecov": "^3.5.0",
     "commitizen": "^4.0.3",
@@ -79,7 +79,7 @@
     "xo": "^0.24.0"
   },
   "peerDependencies": {
-    "semantic-release": ">=15.9.0 <16.0.0"
+    "semantic-release": ">=17.0.4 <18.0.0"
   },
   "prettier": {
     "printWidth": 120,


### PR DESCRIPTION
BREAKING CHANGE: Require Node.js >= 10 as semantic-release does